### PR TITLE
Add force flag when cloning project

### DIFF
--- a/tasks/project.yml
+++ b/tasks/project.yml
@@ -5,6 +5,7 @@
     version: "{{ git_ref }}"
     dest: "{{ project_path }}"
     accept_hostkey: True
+    force: True
   remote_user: "{{ deployer }}"
 
 


### PR DESCRIPTION
By default, since 1.9, Ansible no longer overwrites modified files in the working tree when updating a cloned git repository. To maintain robust deployment behavior that's consistent across Ansible versions, set the 'force' flag to True to re-enable overwriting the working tree. Fixes #9.
