### PR TITLE
deploy to a different dir to fix hot upgrades

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,9 @@ enable_mail_alerts: False
 smtp_port: 587
 smtp_use_tls: False
 
+deploy_to_dir: "/srv/apps"
+deploy_to_path: "{{ deploy_to_dir }}/{{ app_name }}"
+
 # PRIVATE
 smtp_tls_option: ""
 npm_install_options: ""

--- a/tasks/project.yml
+++ b/tasks/project.yml
@@ -92,3 +92,7 @@
   remote_user: "{{ deployer }}"
   environment:
     MIX_ENV: "{{ mix_env }}"
+
+
+- name: "create directory for running app"
+  file: path="{{ deploy_to_path }}" state="directory" owner={{ deployer }}

--- a/tasks/release.yml
+++ b/tasks/release.yml
@@ -10,6 +10,13 @@
   remote_user: "{{ deployer }}"
 
 
+- name: get app version
+  command: bash -lc "mix run -e 'IO.puts \"RELEASE_VERSION=\" <> Mix.Project.config[:version]' | grep RELEASE_VERSION | sed 's/RELEASE_VERSION=//'" chdir="{{ project_path }}"
+  remote_user: "{{ deployer }}"
+  register: app_version_result
+- set_fact: app_version="{{ app_version_result.stdout }}"
+
+
 - name: "create release"
   command: bash -lc 'SERVER=1 mix release' chdir="{{ project_path }}"
   remote_user: "{{ deployer }}"
@@ -18,26 +25,34 @@
     PORT: "{{ app_port }}"
 
 
+- name: "extract release in running app dir"
+  unarchive: src="{{ project_path }}/rel/{{ app_name }}/releases/{{ app_version }}/{{ app_name}}.tar.gz" dest="{{ deploy_to_path }}" owner="{{ deployer }}" copy=no
+
+
 - when: deploy_type == "restart"
   name: start app
   monit: name="{{ app_name }}" state=started
 
 
 - when: deploy_type == "upgrade"
-  name: get app version
-  command: bash -lc "mix run -e 'IO.puts Mix.Project.config[:version]'" chdir="{{ project_path }}"
+  name: "create directory for new release version"
+  file: path="{{ deploy_to_path }}/releases/{{ app_version }}" state="directory" owner={{ deployer }}
+
+
+- when: deploy_type == "upgrade"
+  name: "copy release to running app dir"
+  command: cp {{ project_path }}/rel/{{ app_name }}/releases/{{ app_version }}/{{ app_name}}.tar.gz {{ deploy_to_path }}/releases/{{ app_version }}
   remote_user: "{{ deployer }}"
-  register: app_version
 
 
 - when: deploy_type == "upgrade"
   name: set upgrade command
-  set_fact: upgrade_command='rel/{{ app_name }}/bin/{{ app_name }} upgrade "{{ app_version.stdout }}"'
+  set_fact: upgrade_command='bin/{{ app_name }} upgrade "{{ app_version }}"'
 
 
 - when: deploy_type == "upgrade"
   name: upgrade app
-  command: bash -lc "{{ upgrade_command }}" chdir="{{ project_path }}"
+  command: bash -lc "{{ upgrade_command }}" chdir="{{ deploy_to_path }}"
   remote_user: "{{ deployer }}"
   environment:
     MIX_ENV: "{{ mix_env }}"

--- a/templates/app.monit.j2
+++ b/templates/app.monit.j2
@@ -1,6 +1,6 @@
 check process {{app_name}} MATCHING "{{app_name}}/releases"
-       start program = "/bin/su - {{ deployer }} -c 'PORT={{ app_port }} {{project_path}}/rel/{{app_name}}/bin/{{app_name}} start'"
-       stop program = "/bin/su - {{ deployer }} -c 'PORT={{ app_port }} {{project_path}}/rel/{{app_name}}/bin/{{app_name}} stop'"
+       start program = "/bin/su - {{ deployer }} -c 'PORT={{ app_port }} {{ deploy_to_path }}/bin/{{app_name}} start'"
+       stop program = "/bin/su - {{ deployer }} -c 'PORT={{ app_port }} {{ deploy_to_path }}/bin/{{app_name}} stop'"
        {% for alert_email in app_alert_emails %}
        alert {{ alert_email }}
        {% endfor %}


### PR DESCRIPTION
this still uses `/srv/apps` as directory for the running app.mostly because i already started when i saw your comment. i've seen this pattern often before though and the directory is owned by the deployer user.

upgrading the role requires manually stopping your app once, though. (stop app, run ansible setup). after that, everything work's automatically again.
