### PR TITLE
[DOCS] Change app_endpoint to app_endpoint_module. Prefix ":" before appname

### DIFF
--- a/docs/prod-secret-file.md
+++ b/docs/prod-secret-file.md
@@ -5,11 +5,11 @@ This file is auto-generated when the app is setup. The following template is use
 ```elixir
 use Mix.Config
 
-config {{app_name}}, {{ app_endpoint }},
+config :{{app_name}}, {{ app_endpoint_module }},
   secret_key_base: "{{ secret_key_base }}"
 
 
-config {{ app_name }}, {{ app_repo_module }},
+config :{{ app_name }}, {{ app_repo_module }},
   adapter: Ecto.Adapters.Postgres,
   username: "{{ database_user }}",
   password: "{{ database_password }}",


### PR DESCRIPTION
- By using `{{ app_endpoint }}`, getting `Ansible Undefined VariableError`.
- Without prefixing colon, get undefined "app" error.
