### PR TITLE
fix post-frontend-build command

### DIFF
--- a/tasks/frontend.yml
+++ b/tasks/frontend.yml
@@ -43,5 +43,5 @@
   remote_user: "{{ deployer }}"
   args:
     chdir: "{{ project_path }}"
-    environment:
-      MIX_ENV: "{{ mix_env }}"
+  environment:
+    MIX_ENV: "{{ mix_env }}"


### PR DESCRIPTION
`environment` shouldn't be on arguments list of `command` module
